### PR TITLE
Add time slice for `StimulusData`

### DIFF
--- a/docs/source/submodules/intrinsic_plotter.rst
+++ b/docs/source/submodules/intrinsic_plotter.rst
@@ -16,7 +16,7 @@ Autocorrelograms are a way of displaying whether a unit is respecting the neuron
 over 0 that should have no counts within the refractory period and various counts within bins outside of the refractory period. This function requires
 :code:`SpikeData`, as well as the :code:`ref_dur_ms` (refractory period in milliseconds) to run. 
 
-**Of note** Different neurons have different refractory periods. 2 ms is relatively common, but this should be based on the system the user is studying.
+**Of note Different neurons have different refractory periods. 2 ms is relatively common, but this should be based on the system the user is studying.**
 
 
 .. code-block:: python
@@ -56,7 +56,7 @@ lamina of the cord has most of the units found during sorting.
 
 .. code-block:: python
 
-    iploter.plot_spike_dpeth_fr(sp=spikes) # spikes is SpikeData
+    iplotter.plot_spike_dpeth_fr(sp=spikes) # spikes is SpikeData
 
 CDF
 ---

--- a/docs/source/submodules/spike_analysis.rst
+++ b/docs/source/submodules/spike_analysis.rst
@@ -40,13 +40,14 @@ a value given.
 
 .. code-block:: python
 
-    spiketrain.get_raw_psths(time_bin_ms=0.01, window=[-10,20])
+    spiketrain.get_raw_psth(time_bin_ms=0.01, window=[-10,20]) # same values used
 
 or
 
 .. code-block:: python
 
-    spiketrain.get_raw_psths(time_bin_ms=[0.01, 1], window=[[-10,20], [-1, 2]])
+    # give one time bin and one window per stimulus
+    spiketrain.get_raw_psth(time_bin_ms=[0.01, 1], window=[[-10,20], [-1, 2]])
 
 
 Z-scoring Data
@@ -57,8 +58,16 @@ It is often beneficial to change the :code:`time_bin` for Z scoring to smoothing
 Increasing bin size will allow the large time bins to have a more continuous distribution of spike counts. In order to use this 
 function a :code:`bsl_window` should be given. This should be the pre-stimulus baseline of the neuron/unit. The window is then the window
 over which to Z score. It is beneficial to still include the before and after stimulus windows to better see how the z score has
-changed. Simimlarly each stimulus can have its own window by doing nested lists.
+changed. Simimlarly each stimulus can have its own window by doing nested lists. The math is relatively standard:
 
+.. math::
+
+    Z = \frac{x - \mu}{\sigma}
+
+    z_avg = \frac{1}{n_trials} \Sigma^{n_trials} Z
+
+In our example below we determine both our :math:`\mu` and our :math:`\sigma` with the :code:`bsl_window` and 
+then z score each time bin given by :code:`time_bin_ms` over the :code:`window`
 
 .. code-block:: python
     

--- a/docs/source/submodules/stimulus_data.rst
+++ b/docs/source/submodules/stimulus_data.rst
@@ -37,11 +37,23 @@ is that it uses a memorymap to prevent the whole file from being loaded into RAM
 the large majority of the :code:`.rhd` file is the :code:`amplifier_data` which is used for spike sorting, but not needed
 for this specific step, we can load the stimulus data from extremely large files even with relatively small amounts of RAM.
 **note this is bandwidth limited** so loading from a local drive will be faster than over a network connection. The first
-step is to create the :code:`NEO` reader.
+step is to create the :code:`NEO` reader `NEO <https://neo.readthedocs.io/en/latest/>`_.
 
 .. code-block:: python
 
     stim.create_neo_reader() # creates the memmap for future functions
+
+
+Time Slice
+^^^^^^^^^^
+
+In the case of only wanting to analyze part of a recording a :code:`time_slice` can be used with
+the functions :code:`get_analog_data`, :code:`get_raw_digital_data`, and :code:`run_all`. The 
+general set-up of the :code:`time_slice` is to give the :code:`start` and the :code:`stop` within a
+sequence (start, stop). This needs to be given in seconds and default is :code:`(None, None)`. when
+:code:`None` indicates the beginning or ending of the recording depending on the positioning. For example,
+:code:`time_slice = (None, 10)` would go from the start of the recording to only 10 seconds into the 
+recording.
 
 Processing Analog Stimulus data
 -------------------------------
@@ -53,6 +65,13 @@ In order to assess analog stimulus data the data must first be read with :code:`
 
     stim.get_analog_data()
     stim.digitize_analog_data(stim_length_seconds = 5, stim_name = ['ana_stim']) # ensure length of stimulus is longer than value entered
+
+An example with a slice:
+
+.. code-block:: python
+    
+    stim.get_analog_data(time_slice=(None, 300)) # from start to 6 minutes into recording
+    stim.get_analog_data(time_slice=(60, None)) # ignore first minute of recording
 
 Processing Digital Stimulus data
 --------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -15,7 +15,7 @@ from :code:`pypi` or :code:`conda-forge`. Instead it is built with the included
     (base) $ conda create env -f environment.yml
 
 Alternatively if working in a non-conda system. Pip installation works as well. In 
-this case you can creatae whatever desired virtual environment followed by installing
+this case you can create whatever desired virtual environment followed by installing
 the requirements file :code:`requirements.txt`. Note this requires having :code:`git` 
 installed. To do this installation (note it is recommended to create some kind of 
 virtual environment choose whatever you want):
@@ -53,14 +53,20 @@ There are only five required packages:
 * neo
 * tqdm
 
+**plotting functions require matplotlib to function**
+
 I prefer to build :code:`Neo` from source since it is still actively being developed and I'm 
-working to update the :code:`IntanRawIO`
+working to update the :code:`IntanRawIO`.
+
+Optional Dependency Explanations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 matplotlib is import for the two plotting classes
 pandas is currently only used for one correlation function, but I plan to add a class that uses
 pandas or polar extensively. 
 seaborn is mostly unused, but I may make more use of it in the future
 sklearn is completely unused, but I have plans for it.
+
 
 Development
 -----------
@@ -79,8 +85,10 @@ do the following
 .. code-block:: bash
 
     (base) $ conda create env -f environment_dev.yml
+    (base) $ git clone https://github.com/zm711/spikeanalysis
+    (base) $ cd spikeanalysis
     (base) $ conda activate spikeanalysis_dev
-    (spikeanalysis_dev) $ pip install -e git+https://github.com/zm711/spikeanalysis.git
+    (spikeanalysis_dev) $ pip install -e .
 
 Commits and Testing
 -------------------
@@ -95,7 +103,7 @@ switch them to :code:`" "`. the :code:`params.py` is part of the stimulated data
 
 
 Testing should be done with :code:`pytest` and :code:`pytest-cov`. Optionally the flag for missing lines
-can be included for coverage with :code:`--cov-report missing-terms`.
+can be included for coverage with :code:`--cov-report term-missing`.
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spikeanalysis"
-version = '0.0.0'
+version = '0.0.1'
 authors = [{name="Zach McKenzie", email="mineurs-torrent0x@icloud.com"}]
 description = "Analysis of Spike Trains"
 requires-python = ">=3.9"

--- a/src/spikeanalysis/analysis_utils/latency_functions.py
+++ b/src/spikeanalysis/analysis_utils/latency_functions.py
@@ -26,7 +26,7 @@ def latency_core_stats(bsl_fr: float, firing_data: np.array, time_bin_size: floa
 
 
 @jit(nopython=True)
-def latency_median(firing_counts: np.array, time_bin_size: float):
+def latency_median(firing_counts: np.array, time_bin_size: float): # pragma no cover
     """ "According to Mormann et al. 2008 if neurons fire less than 2Hz they won't really
     follow a poisson distribution and so instead just take latency to first spike as the
     latency and then get the median of the trials"""

--- a/src/spikeanalysis/analysis_utils/latency_functions.py
+++ b/src/spikeanalysis/analysis_utils/latency_functions.py
@@ -26,7 +26,7 @@ def latency_core_stats(bsl_fr: float, firing_data: np.array, time_bin_size: floa
 
 
 @jit(nopython=True)
-def latency_median(firing_counts: np.array, time_bin_size: float): # pragma no cover
+def latency_median(firing_counts: np.array, time_bin_size: float):  # pragma no cover
     """ "According to Mormann et al. 2008 if neurons fire less than 2Hz they won't really
     follow a poisson distribution and so instead just take latency to first spike as the
     latency and then get the median of the trials"""

--- a/src/spikeanalysis/stimulus_data.py
+++ b/src/spikeanalysis/stimulus_data.py
@@ -198,7 +198,7 @@ class StimulusData:
             stim_length_seconds = 8 * self.sample_frequency
         else:
             stim_length_seconds *= self.sample_frequency
-        if analog_index and len(np.shape(self.analog_data))!=1:
+        if analog_index and len(np.shape(self.analog_data)) != 1:
             current_analog_data = self.analog_data[:, analog_index]
         else:
             current_analog_data = self.analog_data

--- a/src/spikeanalysis/stimulus_data.py
+++ b/src/spikeanalysis/stimulus_data.py
@@ -63,11 +63,8 @@ class StimulusData:
         if "dig_analog" in files:
             with open("dig_analog_events.json") as read_file:
                 self.dig_analog_events = json.load(read_file)
-        try:
             raw_analog = glob.glob("raw_analog*")[0]
             self.analog_data = np.load(raw_analog)
-        except IndexError:
-            pass
 
         with open("params.py", "r") as p:
             params = p.readlines()
@@ -80,6 +77,7 @@ class StimulusData:
         stim_index: Optional[int] = None,
         stim_length_seconds: Optional[float] = None,
         stim_name: Optional[list] = None,
+        time_slice=(None, None),
     ):
         """
         Pipeline function to run through all steps necessary to load intan data
@@ -92,6 +90,8 @@ class StimulusData:
             The length (seconds) of the analog stimuli to digitize them. The default is None.
         stim_name : Optional[list], optional
             Name of the stimulus. The default is None.
+        time_slice: tuple[start, stop]
+            time slice of recording to use, given in seconds with start and stop
 
         """
 
@@ -103,12 +103,12 @@ class StimulusData:
 
         self.create_neo_reader()
         try:
-            self.get_analog_data()
+            self.get_analog_data(time_slice=time_slice)
             HAVE_ANALOG = True
         except AssertionError:
             HAVE_ANALOG = False
 
-        self.get_raw_digital_data()
+        self.get_raw_digital_data(time_slice=time_slice)
         try:
             len(np.isnan(self._raw_digital_data))
             HAVE_DIGITAL = True
@@ -141,13 +141,30 @@ class StimulusData:
         self.sample_frequency = sample_freq
         self.reader = reader
 
-    def get_analog_data(self):
+    def get_analog_data(self, time_slice=(None, None)):
         """
         Function to load analog data from an Intan file. Requires the IntanRawIO to be generated with
         `create_neo_reader`
 
+        Parameters
+        ----------
+        time_slice: tuple[start, stop]
+            time slice of the data to analyze given in seconds with format (start, stop)
+            None for start indicates start at 0, None for stop indicates go to end of
+            recording
+
         """
-        stream_list = list()
+
+        if time_slice[0] is not None:
+            i_start = int(np.rint(time_slice[0] * self.sample_frequency))
+        else:
+            i_start = None
+        if time_slice[1] is not None:
+            i_stop = int(np.rint(time_slice[1] * self.sample_frequency))
+        else:
+            i_stop = None
+
+        stream_list = []
         for value in self.reader.header["signal_streams"]:
             stream_list.append(str(value[0]))
         adc_stream = [idx for idx, name in enumerate(stream_list) if "ADC" in name.upper()]
@@ -155,6 +172,8 @@ class StimulusData:
         adc_stream = adc_stream[0]
         adc_data = self.reader.get_analogsignal_chunk(
             stream_index=adc_stream,
+            i_start=i_start,
+            i_stop=i_stop,
         )
 
         final_adc = np.squeeze(
@@ -179,8 +198,8 @@ class StimulusData:
             stim_length_seconds = 8 * self.sample_frequency
         else:
             stim_length_seconds *= self.sample_frequency
-        if analog_index:
-            current_analog_data = self.analog_data[analog_index, :]
+        if analog_index and len(np.shape(self.analog_data))!=1:
+            current_analog_data = self.analog_data[:, analog_index]
         else:
             current_analog_data = self.analog_data
 
@@ -192,7 +211,6 @@ class StimulusData:
             self.dig_analog_events[str(row)] = {}
             sub_data = current_analog_data[:, row]
             filtered_analog_data = np.where(sub_data > 0.09, 1, 0)
-
             dig_ana_events, dig_ana_lengths = self._calculate_events(filtered_analog_data)
             events = dig_ana_events[dig_ana_lengths > stim_length_seconds]
             lengths = dig_ana_lengths[dig_ana_lengths > stim_length_seconds]
@@ -233,7 +251,7 @@ class StimulusData:
         """
         return round(base * round(float(x) / base), precision)
 
-    def get_raw_digital_data(self):
+    def get_raw_digital_data(self, time_slice=(None, None)):
         """
         This is a function that in the future will get the digital data, but currently due
         to the inability to grab digital from neo automatically. Calls on internal hack to
@@ -248,7 +266,7 @@ class StimulusData:
         # assert len(digital_stream) >0, "There is no digital-in data"
         # digital_stream = digital_stream[0]
         try:
-            digital_data = self._intan_neo_read_no_dig(self.reader)
+            digital_data = self._intan_neo_read_no_dig(self.reader, time_slice=time_slice)
         except:
             digital_data = np.nan
 
@@ -425,15 +443,11 @@ class StimulusData:
             _ = self.dig_analog_events
             with open("dig_analog_events.json", "w") as write_file:
                 json.dump(self.dig_analog_events, write_file, cls=NumpyEncoder)
+            np.save("raw_analog_data.npy", self.analog_data)
         except AttributeError:
             print("No analog events to save")
 
-        try:
-            np.save("raw_analog_data.npy", self.analog_data)
-        except AttributeError:
-            print("No raw analog data to save")
-
-    def _intan_neo_read_no_dig(self, reader: neo.rawio.IntanRawIO) -> np.array:
+    def _intan_neo_read_no_dig(self, reader: neo.rawio.IntanRawIO, time_slice=(None, None)) -> np.array:
         """
         Utility function that hacks the Neo memmap structure to be able to read
         digital events.
@@ -442,6 +456,10 @@ class StimulusData:
         ----------
         reader : neo.rawio.IntanRawIO
             The current file reader containing the memmap to the .rhd file.
+        time_slice: tuple[start, stop]
+            time slice of the data to analyze given in seconds with format (start, stop)
+            None for start indicates start at 0, None for stop indicates go to end of
+            recording
 
         Returns
         -------
@@ -453,8 +471,14 @@ class StimulusData:
         dig_size = digital_memmap.size
         dig_shape = digital_memmap.shape
         # below we have all the shaping information necessary
-        i_start = 0
-        i_stop = dig_size
+        if time_slice[0] is not None:
+            i_start = int(np.rint(time_slice[0] * self.sample_frequency))
+        else:
+            i_start = 0
+        if time_slice[1] is not None:
+            i_stop = int(np.rint(time_slice[1] * self.sample_frequency))
+        else:
+            i_stop = dig_size
         block_size = dig_shape[1]
         block_start = i_start // block_size
         block_stop = i_stop // block_size + 1

--- a/test/test_stimulus_data.py
+++ b/test/test_stimulus_data.py
@@ -35,15 +35,21 @@ def test_get_analog_data_time_slice(stim):
     print(stim.analog_data)
     assert np.shape(stim.analog_data) == (18000,)
 
+
 def test_get_analog_data_slice_none(stim):
-
-    stim.get_analog_data(time_slice=(None, 8.,))
+    stim.get_analog_data(
+        time_slice=(
+            None,
+            8.0,
+        )
+    )
     print(stim.analog_data)
-    assert len(stim.analog_data)==24000
+    assert len(stim.analog_data) == 24000
 
-    stim.get_analog_data(time_slice = (2., None))
+    stim.get_analog_data(time_slice=(2.0, None))
     print(stim.analog_data)
-    assert len(stim.analog_data)==56080
+    assert len(stim.analog_data) == 56080
+
 
 def test_digitize_analog_data(stim):
     stim.get_analog_data()
@@ -55,25 +61,26 @@ def test_digitize_analog_data(stim):
     assert "events" in stim.dig_analog_events["0"].keys()
     assert "lengths" in stim.dig_analog_events["0"].keys()
     assert "trial_groups" in stim.dig_analog_events["0"].keys()
-    assert stim.dig_analog_events['0']['stim']=='0'
+    assert stim.dig_analog_events["0"]["stim"] == "0"
 
     # test by creating actual analog events
-    stim.analog_data[10000:16000]=9.50
-    stim.analog_data[9000:10000]=0
-    stim.analog_data[16000:17000]=0
-    stim.digitize_analog_data(stim_length_seconds=.1, analog_index = 0, stim_name=['test'])
+    stim.analog_data[10000:16000] = 9.50
+    stim.analog_data[9000:10000] = 0
+    stim.analog_data[16000:17000] = 0
+    stim.digitize_analog_data(stim_length_seconds=0.1, analog_index=0, stim_name=["test"])
     print(stim.dig_analog_events)
 
-    assert stim.dig_analog_events['0']['stim'] == 'test'
-    assert stim.dig_analog_events['0']['events'][1]==9999
-    assert stim.dig_analog_events['0']['lengths'][1]==6000
-    assert stim.dig_analog_events['0']['trial_groups'][1]==38
-    
+    assert stim.dig_analog_events["0"]["stim"] == "test"
+    assert stim.dig_analog_events["0"]["events"][1] == 9999
+    assert stim.dig_analog_events["0"]["lengths"][1] == 6000
+    assert stim.dig_analog_events["0"]["trial_groups"][1] == 38
+
     stim.analog_data = np.expand_dims(stim.analog_data, axis=1)
-    stim.digitize_analog_data(stim_length_seconds=.1, analog_index = 0, stim_name=['test'])
-    
+    stim.digitize_analog_data(stim_length_seconds=0.1, analog_index=0, stim_name=["test"])
+
     # test stim_index with multiple columns (just test it doesn't error)
     assert stim.dig_analog_events
+
 
 def test_json_writer(stim, tmp_path):
     stim.get_analog_data()
@@ -133,21 +140,32 @@ def test_get_raw_digital_events(stim):
     assert stim._raw_digital_data[-1] == 1
     assert stim._raw_digital_data[0] == 0
 
-def test_get_raw_digital_events_slice(stim):
 
-    stim.get_raw_digital_data(time_slice=(2., 8.,))
+def test_get_raw_digital_events_slice(stim):
+    stim.get_raw_digital_data(
+        time_slice=(
+            2.0,
+            8.0,
+        )
+    )
     print(stim._raw_digital_data)
     assert len(stim._raw_digital_data) == 18000
 
+
 def test_get_raw_digital_events_slice_none(stim):
-
-    stim.get_raw_digital_data(time_slice=(None, 8.,))
+    stim.get_raw_digital_data(
+        time_slice=(
+            None,
+            8.0,
+        )
+    )
     print(stim._raw_digital_data)
-    assert len(stim._raw_digital_data)==24000
+    assert len(stim._raw_digital_data) == 24000
 
-    stim.get_raw_digital_data(time_slice = (2., None))
+    stim.get_raw_digital_data(time_slice=(2.0, None))
     print(stim._raw_digital_data)
-    assert len(stim._raw_digital_data)==56080
+    assert len(stim._raw_digital_data) == 56080
+
 
 def test_get_raw_nan(stim):
     import copy
@@ -158,6 +176,7 @@ def test_get_raw_nan(stim):
 
     assert np.isnan(stim2._raw_digital_data)
 
+
 def test_final_digital_data(stim):
     stim.get_raw_digital_data()
     stim.get_final_digital_data()
@@ -165,8 +184,8 @@ def test_final_digital_data(stim):
     assert stim.digital_data[0, -1] == 0.0
     assert stim.dig_in_channels[0]["native_channel_name"] == "DIGITAL-IN-01"
 
-def test_final_digital_data_failure(stim):
 
+def test_final_digital_data_failure(stim):
     stim._raw_digital_data = np.nan
 
     with pytest.raises(Exception):
@@ -210,10 +229,11 @@ def test_get_stimulus_channels(stim):
     assert isinstance(stim_dict, dict)
     assert "DIGITAL-IN-01" in stim_dict.keys()
 
-def test_fail_stimulus_channels(stim):
 
+def test_fail_stimulus_channels(stim):
     with pytest.raises(Exception):
         stim.get_stimulus_channels()
+
 
 def test_set_trial_groups(stim):
     stim.get_raw_digital_data()
@@ -239,10 +259,11 @@ def test_failed_trial_groups_stim_names(stim):
     stim.generate_digital_events()
 
     with pytest.raises(Exception):
-        stim.set_trial_groups(trial_dictionary={'RANDOM':'RANDOM'})
+        stim.set_trial_groups(trial_dictionary={"RANDOM": "RANDOM"})
 
     with pytest.raises(Exception):
-        stim.set_stimulus_name(stim_names={'RANDOM': 'RANDOM'})
+        stim.set_stimulus_name(stim_names={"RANDOM": "RANDOM"})
+
 
 def test_set_stimulus_name(stim):
     stim.get_raw_digital_data()
@@ -272,4 +293,3 @@ def test_run_all(stim):
     assert stim.analog_data.any()
     assert isinstance(stim.dig_analog_events, dict)
     assert isinstance(stim.digital_events, dict)
-

--- a/test/test_stimulus_data.py
+++ b/test/test_stimulus_data.py
@@ -30,6 +30,21 @@ def test_get_analog_data(stim):
     assert np.shape(stim.analog_data) == (62080,)
 
 
+def test_get_analog_data_time_slice(stim):
+    stim.get_analog_data(time_slice=(2.0, 8.0))
+    print(stim.analog_data)
+    assert np.shape(stim.analog_data) == (18000,)
+
+def test_get_analog_data_slice_none(stim):
+
+    stim.get_analog_data(time_slice=(None, 8.,))
+    print(stim.analog_data)
+    assert len(stim.analog_data)==24000
+
+    stim.get_analog_data(time_slice = (2., None))
+    print(stim.analog_data)
+    assert len(stim.analog_data)==56080
+
 def test_digitize_analog_data(stim):
     stim.get_analog_data()
     stim.digitize_analog_data()
@@ -40,7 +55,25 @@ def test_digitize_analog_data(stim):
     assert "events" in stim.dig_analog_events["0"].keys()
     assert "lengths" in stim.dig_analog_events["0"].keys()
     assert "trial_groups" in stim.dig_analog_events["0"].keys()
+    assert stim.dig_analog_events['0']['stim']=='0'
 
+    # test by creating actual analog events
+    stim.analog_data[10000:16000]=9.50
+    stim.analog_data[9000:10000]=0
+    stim.analog_data[16000:17000]=0
+    stim.digitize_analog_data(stim_length_seconds=.1, analog_index = 0, stim_name=['test'])
+    print(stim.dig_analog_events)
+
+    assert stim.dig_analog_events['0']['stim'] == 'test'
+    assert stim.dig_analog_events['0']['events'][1]==9999
+    assert stim.dig_analog_events['0']['lengths'][1]==6000
+    assert stim.dig_analog_events['0']['trial_groups'][1]==38
+    
+    stim.analog_data = np.expand_dims(stim.analog_data, axis=1)
+    stim.digitize_analog_data(stim_length_seconds=.1, analog_index = 0, stim_name=['test'])
+    
+    # test stim_index with multiple columns (just test it doesn't error)
+    assert stim.dig_analog_events
 
 def test_json_writer(stim, tmp_path):
     stim.get_analog_data()
@@ -100,6 +133,30 @@ def test_get_raw_digital_events(stim):
     assert stim._raw_digital_data[-1] == 1
     assert stim._raw_digital_data[0] == 0
 
+def test_get_raw_digital_events_slice(stim):
+
+    stim.get_raw_digital_data(time_slice=(2., 8.,))
+    print(stim._raw_digital_data)
+    assert len(stim._raw_digital_data) == 18000
+
+def test_get_raw_digital_events_slice_none(stim):
+
+    stim.get_raw_digital_data(time_slice=(None, 8.,))
+    print(stim._raw_digital_data)
+    assert len(stim._raw_digital_data)==24000
+
+    stim.get_raw_digital_data(time_slice = (2., None))
+    print(stim._raw_digital_data)
+    assert len(stim._raw_digital_data)==56080
+
+def test_get_raw_nan(stim):
+    import copy
+
+    stim2 = copy.deepcopy(stim)
+    del stim2.reader
+    stim2.get_raw_digital_data()
+
+    assert np.isnan(stim2._raw_digital_data)
 
 def test_final_digital_data(stim):
     stim.get_raw_digital_data()
@@ -107,6 +164,13 @@ def test_final_digital_data(stim):
     assert np.shape(stim.digital_data) == (1, 62080)
     assert stim.digital_data[0, -1] == 0.0
     assert stim.dig_in_channels[0]["native_channel_name"] == "DIGITAL-IN-01"
+
+def test_final_digital_data_failure(stim):
+
+    stim._raw_digital_data = np.nan
+
+    with pytest.raises(Exception):
+        stim.get_final_digital_data()
 
 
 def test_generate_digital_events(stim):
@@ -146,6 +210,10 @@ def test_get_stimulus_channels(stim):
     assert isinstance(stim_dict, dict)
     assert "DIGITAL-IN-01" in stim_dict.keys()
 
+def test_fail_stimulus_channels(stim):
+
+    with pytest.raises(Exception):
+        stim.get_stimulus_channels()
 
 def test_set_trial_groups(stim):
     stim.get_raw_digital_data()
@@ -164,6 +232,17 @@ def test_set_trial_groups(stim):
     assert stim.digital_events["DIGITAL-IN-01"]["trial_groups"][0] == 3.0
     assert stim.digital_events["DIGITAL-IN-01"]["trial_groups"][1] == 4.0
 
+
+def test_failed_trial_groups_stim_names(stim):
+    stim.get_raw_digital_data()
+    stim.get_final_digital_data()
+    stim.generate_digital_events()
+
+    with pytest.raises(Exception):
+        stim.set_trial_groups(trial_dictionary={'RANDOM':'RANDOM'})
+
+    with pytest.raises(Exception):
+        stim.set_stimulus_name(stim_names={'RANDOM': 'RANDOM'})
 
 def test_set_stimulus_name(stim):
     stim.get_raw_digital_data()
@@ -193,3 +272,4 @@ def test_run_all(stim):
     assert stim.analog_data.any()
     assert isinstance(stim.dig_analog_events, dict)
     assert isinstance(stim.digital_events, dict)
+


### PR DESCRIPTION
In case a recording needs to be truncated use `Neo`'s ability for timeslices to allow for this truncation. Added tests, fixed a couple bugs based on these tests.