### PR TITLE
Refactor `SpikeAnalysis`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2023, Zach McKenzie"
 author = "Zach McKenzie"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.5"
+release = "0.0.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spikeanalysis"
-version = '0.0.5'
+version = '0.0.6'
 authors = [{name="Zach McKenzie", email="mineurs-torrent0x@icloud.com"}]
 description = "Analysis of Spike Trains"
 requires-python = ">=3.9"

--- a/src/spikeanalysis/spike_analysis.py
+++ b/src/spikeanalysis/spike_analysis.py
@@ -571,10 +571,8 @@ class SpikeAnalysis:
 
         correlations = {}
         for idx, stimulus in enumerate(data.keys()):
-            if idx < self.NUM_DIG:
-                trial_groups = np.array(self.digital_events[stim_dict[stimulus]]["trial_groups"])
-            else:
-                trial_groups = np.array(self.dig_analog_events[str(idx - self.NUM_DIG)]["trial_groups"])
+
+            trial_groups = np.array(self.events[stim_dict[stimulus]]["trial_groups"])
             current_window = windows[idx]
             current_data = data[stimulus]
 

--- a/src/spikeanalysis/spike_analysis.py
+++ b/src/spikeanalysis/spike_analysis.py
@@ -126,6 +126,15 @@ class SpikeAnalysis:
             self.HAVE_ANALOG = False
             print("There is no raw analog data provided. Run get_analog_data if needed.")
 
+        if self.HAVE_DIGITAL and self.HAVE_DIG_ANALOG:
+            self.events = self._merge_events(self.digital_events, self.dig_analog_events)
+        elif self.HAVE_DIGITAL:
+            self.events = self.digital_events
+        elif self.HAVE_DIG_ANALOG:
+            self.events = self.dig_analog_events
+        else:
+            raise Exception('Code requires some stimulus data')
+
     def get_raw_psth(
         self,
         window: Union[list, list[list]],
@@ -850,6 +859,11 @@ class SpikeAnalysis:
                 responsive_neurons = np.where(z_above_threshold > current_n_bins, True, False)
 
                 self.responsive_neurons[stim][key] = responsive_neurons
+
+    def _merge_events(self, event_0, event_1):
+        """Utility function for merging digital and analog events into one dictionary"""
+        events = {**event_0, **event_1}
+        return events
 
     def _get_key_for_stim(self) -> dict:
         """

--- a/src/spikeanalysis/spike_analysis.py
+++ b/src/spikeanalysis/spike_analysis.py
@@ -19,14 +19,17 @@ class SpikeAnalysis:
     """Class for spike train analysis utilizing a SpikeData object and a StimulusData object"""
 
     def __init__(self):
-        pass
+        self._file_path = None
+        self.events = {}
 
     def __repr__(self):
         var_methods = dir(self)
         var = list(vars(self).keys())  # get our currents variables
         methods = list(set(var_methods) - set(var))
         final_methods = [method for method in methods if "__" not in method and method[0] != "_"]
-        return f"The methods are {final_methods}"
+        final_vars = [current_var for current_var in var if "_" not in current_var]
+        print(f"The methods are: {final_methods}")
+        print(f"Variables are: {final_vars}")
 
     def set_spike_data(self, sp: SpikeData):
         """
@@ -42,14 +45,14 @@ class SpikeAnalysis:
         None.
 
         """
-        try:
-            file_path = self._file_path
-            assert (
-                file_path == sp._file_path
-            ), f"Stim data and Spike data must have same root Stim: {file_path}, spike:\
-                {sp._file_path}"
-        except AttributeError:
+        if self._file_path is None:
             self._file_path = sp._file_path
+        else:
+            assert (
+                self._file_path == sp._file_path
+            ), f"Stim data and Spike data must have same root Stim: {self._file_path}, spike:\
+                {sp._file_path}"
+
         try:
             self.spike_times = sp.spike_times
         except AttributeError:
@@ -97,14 +100,13 @@ class SpikeAnalysis:
         None.
 
         """
-        try:
-            file_path = self._file_path
-            assert (
-                file_path == event_times._file_path
-            ), f"Stim data and Spike data must have same root Stim: \
-                {event_times._file_path}, Spike: {file_path}"
-        except AttributeError:
+        if self._file_path is None:
             self._file_path = event_times._file_path
+        else:
+            assert (
+                self._file_path == event_times._file_path
+            ), f"Stim data and Spike data must have same root Stim: \
+                {event_times._file_path}, Spike: {self._file_path}"
 
         try:
             self.digital_events = event_times.digital_events
@@ -118,7 +120,9 @@ class SpikeAnalysis:
             self.HAVE_DIG_ANALOG = True
         except AttributeError as err:
             self.HAVE_DIG_ANALOG = False
-            print(f"{err}. Run possible analog functions {_possible_analog} if should be present.")
+            print(
+                f"{err}. If should be present. Run possible analog functions {_possible_analog} if should be present."
+            )
         try:
             self.analog_data = event_times.analog_data
             self.HAVE_ANALOG = True
@@ -133,7 +137,7 @@ class SpikeAnalysis:
         elif self.HAVE_DIG_ANALOG:
             self.events = self.dig_analog_events
         else:
-            raise Exception('Code requires some stimulus data')
+            raise Exception("Code requires some stimulus data")
 
     def get_raw_psth(
         self,
@@ -171,7 +175,7 @@ class SpikeAnalysis:
         TOTAL_STIM = len(self.events.keys())
         windows = verify_window_format(window=window, num_stim=TOTAL_STIM)
         psths = {}
-        
+
         for idx, stimulus in enumerate(self.events.keys()):
             multispike_bin = 0
             events = np.array(self.events[stimulus]["events"])
@@ -342,7 +346,6 @@ class SpikeAnalysis:
         psths = self.psths
         self.latency = {}
         for idx, stim in enumerate(self.psths.keys()):
-
             trials = self.events[stim_dict[stim]]["trial_groups"]
             print(stim)
             trial_set = np.unique(np.array(trials))
@@ -481,9 +484,7 @@ class SpikeAnalysis:
                     final_counts[idy, idz, :] = isi_counts
                     final_counts_bsl[idy, idz, :] = bsl_counts
                     raw_data[stim_name][cluster]["isi_values"].append(list(current_isi_raw / self._sampling_rate))
-                    raw_data[stim_name][cluster]["bsl_isi_values"].append(
-                        list(baseline_isi_raw / self._sampling_rate)
-                    )
+                    raw_data[stim_name][cluster]["bsl_isi_values"].append(list(baseline_isi_raw / self._sampling_rate))
                 raw_data[stim_name][cluster]["isi_values"] = np.array(
                     [value for sub_list in raw_data[stim_name][cluster]["isi_values"] for value in sub_list]
                 )
@@ -571,7 +572,6 @@ class SpikeAnalysis:
 
         correlations = {}
         for idx, stimulus in enumerate(data.keys()):
-
             trial_groups = np.array(self.events[stim_dict[stimulus]]["trial_groups"])
             current_window = windows[idx]
             current_data = data[stimulus]

--- a/src/spikeanalysis/spike_analysis.py
+++ b/src/spikeanalysis/spike_analysis.py
@@ -168,11 +168,8 @@ class SpikeAnalysis:
             minumum bin size in ms is {1000/self._sampling_rate}"
 
         time_bin_size = np.int64((time_bin_ms / 1000) * self._sampling_rate)
-
         TOTAL_STIM = len(self.events.keys())
-
         windows = verify_window_format(window=window, num_stim=TOTAL_STIM)
-
         psths = {}
         
         for idx, stimulus in enumerate(self.events.keys()):
@@ -259,9 +256,7 @@ class SpikeAnalysis:
         except AttributeError:
             raise Exception("Run get_raw_psth before running z_score_data")
 
-
         stim_dict = self._get_key_for_stim()
-
         NUM_STIM = self.NUM_STIM
 
         if isinstance(time_bin_ms, float) or isinstance(time_bin_ms, int):
@@ -313,12 +308,10 @@ class SpikeAnalysis:
                 mean_fr = np.mean(np.sum(bsl_trial, axis=2), axis=1) / ((bsl_current[1] - bsl_current[0]))
                 std_fr = np.std(np.sum(bsl_trial, axis=2), axis=1) / ((bsl_current[1] - bsl_current[0]))
                 z_trial = z_psth[:, trials == trial, :] / time_bin_current
-
                 z_trials = hf.z_score_values(z_trial, mean_fr, std_fr)
-
                 z_scores[stim][:, trials == trial, :] = z_trials[:, :, :]
-
                 final_z_scores[stim][:, trial_number, :] = np.nanmean(z_trials, axis=1)
+
             self.z_bins[stim] = bins[z_window_values]
         self.z_scores = final_z_scores
 

--- a/src/spikeanalysis/spike_data.py
+++ b/src/spikeanalysis/spike_data.py
@@ -507,7 +507,7 @@ class SpikeData:
             if self.CACHING:
                 np.save("qc_threshold.npy", threshold)
 
-            if np.sum(threshold)==0:
+            if np.sum(threshold) == 0:
                 print("Current qc_preprocessing values led to 0 units.")
                 print(f"Iso: {np.sum(iso_d_thres)}, sil: {np.sum(sil)}")
                 print(f"RPV: {np.sum(rpv)}")

--- a/src/spikeanalysis/spike_data.py
+++ b/src/spikeanalysis/spike_data.py
@@ -507,6 +507,11 @@ class SpikeData:
             if self.CACHING:
                 np.save("qc_threshold.npy", threshold)
 
+            if np.sum(threshold)==0:
+                print("Current qc_preprocessing values led to 0 units.")
+                print(f"Iso: {np.sum(iso_d_thres)}, sil: {np.sum(sil)}")
+                print(f"RPV: {np.sum(rpv)}")
+
         self._return_to_dir(current_dir)
 
     def set_qc(self):

--- a/test/test_spike_analysis.py
+++ b/test/test_spike_analysis.py
@@ -77,7 +77,7 @@ def test_get_raw_psths(sa_mocked):
 
 
 def test_z_score_data(sa):
-    sa.dig_analog_events = {
+    sa.events = {
         "0": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),
@@ -136,7 +136,7 @@ def test_compute_event_interspike_intervals(sa_mocked):
 
 
 def test_compute_event_interspike_intervals_digital(sa_mocked):
-    sa_mocked.digital_events = {
+    sa_mocked.events = {
         "DIGITAL-IN-01": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),
@@ -144,7 +144,6 @@ def test_compute_event_interspike_intervals_digital(sa_mocked):
             "stim": "DIG",
         }
     }
-    sa_mocked.HAVE_DIGITAL = True
     sa_mocked.get_raw_psth(
         window=[0, 300],
         time_bin_ms=50,
@@ -153,11 +152,19 @@ def test_compute_event_interspike_intervals_digital(sa_mocked):
     sa_mocked.compute_event_interspike_intervals(200)
 
     print(sa_mocked.isi)
-    sa_mocked.HAVE_DIGITAL = False
 
     assert len(sa_mocked.isi.keys()) == 2
 
     nptest.assert_array_equal(sa_mocked.isi["DIG"]["bins"], sa_mocked.isi["test"]["bins"])
+
+    sa.events = {
+        "0": {
+            "events": np.array([100, 200]),
+            "lengths": np.array([100, 100]),
+            "trial_groups": np.array([1, 1]),
+            "stim": "test",
+        }
+    }
 
 
 def test_trial_correlation_exception(sa):
@@ -169,7 +176,7 @@ def test_trial_correlation_exception(sa):
 
 
 def test_trial_correlation(sa):
-    sa.dig_analog_events = {
+    sa.events= {
         "0": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),
@@ -212,7 +219,7 @@ def test_generate_z_scores(sa, tmp_path):
 def test_get_key_for_stim(sa):
     mocked_digital_events = {"DIG-IN-01": {"stim": "test"}}
 
-    sa.digital_events = mocked_digital_events
+    sa.events = mocked_digital_events
     stim_name = "test"  # from mocked data
     channel = "DIG-IN-01"  # from mocked data
 
@@ -269,7 +276,7 @@ def test_responsive_neurons(sa):
 
 
 def test_latencies(sa):
-    sa.dig_analog_events = {
+    sa.events = {
         "0": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),

--- a/test/test_spike_analysis.py
+++ b/test/test_spike_analysis.py
@@ -32,6 +32,19 @@ def test_attributes_sa(sa):
     assert sa.HAVE_DIG_ANALOG
     assert len(sa.raw_spike_times) == 10
 
+def test_merge_dicts(sa):
+    dict1 = {1: {'a': [1,2,3]}}
+    dict2 = {2: {'b': [4,5,6]}}
+
+    merged_dict = sa._merge_events(dict1,dict2)
+    assert isinstance(merged_dict, dict)
+
+    for key in [1,2]:
+        assert key in merged_dict.keys()
+    
+    for value in merged_dict.values():
+        assert isinstance(value, dict)
+
 
 @pytest.fixture(scope="module")
 def sa_mocked(sa):

--- a/test/test_spike_analysis.py
+++ b/test/test_spike_analysis.py
@@ -32,16 +32,17 @@ def test_attributes_sa(sa):
     assert sa.HAVE_DIG_ANALOG
     assert len(sa.raw_spike_times) == 10
 
-def test_merge_dicts(sa):
-    dict1 = {1: {'a': [1,2,3]}}
-    dict2 = {2: {'b': [4,5,6]}}
 
-    merged_dict = sa._merge_events(dict1,dict2)
+def test_merge_dicts(sa):
+    dict1 = {1: {"a": [1, 2, 3]}}
+    dict2 = {2: {"b": [4, 5, 6]}}
+
+    merged_dict = sa._merge_events(dict1, dict2)
     assert isinstance(merged_dict, dict)
 
-    for key in [1,2]:
+    for key in [1, 2]:
         assert key in merged_dict.keys()
-    
+
     for value in merged_dict.values():
         assert isinstance(value, dict)
 
@@ -136,14 +137,16 @@ def test_compute_event_interspike_intervals(sa_mocked):
 
 
 def test_compute_event_interspike_intervals_digital(sa_mocked):
-    sa_mocked.events.update({
-        "DIGITAL-IN-01": {
-            "events": np.array([100, 200]),
-            "lengths": np.array([100, 100]),
-            "trial_groups": np.array([1, 1]),
-            "stim": "DIG",
+    sa_mocked.events.update(
+        {
+            "DIGITAL-IN-01": {
+                "events": np.array([100, 200]),
+                "lengths": np.array([100, 100]),
+                "trial_groups": np.array([1, 1]),
+                "stim": "DIG",
+            }
         }
-    })
+    )
     sa_mocked.get_raw_psth(
         window=[0, 300],
         time_bin_ms=50,
@@ -176,7 +179,7 @@ def test_trial_correlation_exception(sa):
 
 
 def test_trial_correlation(sa):
-    sa.events= {
+    sa.events = {
         "0": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),

--- a/test/test_spike_analysis.py
+++ b/test/test_spike_analysis.py
@@ -48,7 +48,7 @@ def test_merge_dicts(sa):
 
 @pytest.fixture(scope="module")
 def sa_mocked(sa):
-    sa.dig_analog_events = {
+    sa.events = {
         "0": {"events": np.array([100]), "lengths": np.array([200]), "trial_groups": np.array([1]), "stim": "test"}
     }
 
@@ -136,14 +136,14 @@ def test_compute_event_interspike_intervals(sa_mocked):
 
 
 def test_compute_event_interspike_intervals_digital(sa_mocked):
-    sa_mocked.events = {
+    sa_mocked.events.update({
         "DIGITAL-IN-01": {
             "events": np.array([100, 200]),
             "lengths": np.array([100, 100]),
             "trial_groups": np.array([1, 1]),
             "stim": "DIG",
         }
-    }
+    })
     sa_mocked.get_raw_psth(
         window=[0, 300],
         time_bin_ms=50,


### PR DESCRIPTION
- merge `digital` and `analog` events into one `dict`
- remove duplication of code for separate `dig` vs `analog`
- update tests for new `events` structure
- add warning if `qc_preprocessing` removed all potential units